### PR TITLE
feat: add Gene Normalizer sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wags_tails"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     {name = "Kori Kuzma"},
     {name = "James S Stevenson"},

--- a/src/wags_tails/__init__.py
+++ b/src/wags_tails/__init__.py
@@ -11,7 +11,7 @@ from .guide_to_pharmacology import GToPLigandData
 from .hemonc import HemOncData
 from .hgnc import HgncData
 from .mondo import MondoData
-from .ncbi import NcbiGenomeData
+from .ncbi import NcbiGeneData, NcbiGenomeData
 from .ncit import NcitData
 from .oncotree import OncoTreeData
 from .rxnorm import RxNormData
@@ -30,6 +30,7 @@ __all__ = [
     "HemOncData",
     "HgncData",
     "MondoData",
+    "NcbiGeneData",
     "NcbiGenomeData",
     "NcitData",
     "OncoTreeData",

--- a/src/wags_tails/__init__.py
+++ b/src/wags_tails/__init__.py
@@ -6,9 +6,12 @@ from .custom import CustomData
 from .do import DoData
 from .drugbank import DrugBankData
 from .drugsatfda import DrugsAtFdaData
+from .ensembl import EnsemblData
 from .guide_to_pharmacology import GToPLigandData
 from .hemonc import HemOncData
+from .hgnc import HgncData
 from .mondo import MondoData
+from .ncbi import NcbiGenomeData
 from .ncit import NcitData
 from .oncotree import OncoTreeData
 from .rxnorm import RxNormData
@@ -22,9 +25,12 @@ __all__ = [
     "DoData",
     "DrugBankData",
     "DrugsAtFdaData",
+    "EnsemblData",
     "GToPLigandData",
     "HemOncData",
+    "HgncData",
     "MondoData",
+    "NcbiGenomeData",
     "NcitData",
     "OncoTreeData",
     "RxNormData",

--- a/src/wags_tails/ensembl.py
+++ b/src/wags_tails/ensembl.py
@@ -1,0 +1,42 @@
+"""Provide data management for Ensembl genomic data."""
+from pathlib import Path
+
+import requests
+
+from wags_tails.base_source import DataSource
+from wags_tails.utils.downloads import download_ftp, handle_gzip
+
+
+class EnsemblData(DataSource):
+    """Provide access to Ensembl data."""
+
+    _src_name = "ensembl"
+    _filetype = "gff"
+
+    def _get_latest_version(self) -> str:
+        """Retrieve latest version value
+
+        :return: latest release value
+        """
+        url = "https://rest.ensembl.org/info/data/?content-type=application/json"
+        response = requests.get(url)
+        response.raise_for_status()
+        releases = response.json()["releases"]
+        releases.sort()
+        latest_version = releases[-1]
+        return f"GRCh38_{latest_version}"
+
+    def _download_data(self, version: str, outfile: Path) -> None:
+        """Download data file to specified location.
+
+        :param version: version to acquire
+        :param outfile: location and filename for final data file
+        """
+        download_ftp(
+            "ftp.ensembl.org",
+            "pub/current_gff3/homo_sapiens/",
+            f"Homo_sapiens.GRCh38.{version.split('_')[1]}.gff3.gz",
+            outfile,
+            handler=handle_gzip,
+            tqdm_params=self._tqdm_params,
+        )

--- a/src/wags_tails/hgnc.py
+++ b/src/wags_tails/hgnc.py
@@ -1,0 +1,41 @@
+"""Provide data fetching for HGNC."""
+import ftplib
+from pathlib import Path
+
+from wags_tails.base_source import DataSource
+from wags_tails.utils.downloads import download_ftp
+
+
+class HgncData(DataSource):
+    """Provide access to ChEMBL database."""
+
+    _src_name = "hgnc"
+    _filetype = "json"
+
+    _host = "ftp.ebi.ac.uk"
+    _directory_path = "pub/databases/genenames/hgnc/json/"
+    _host_filename = "hgnc_complete_set.json"
+
+    def _get_latest_version(self) -> str:
+        """Retrieve latest version value
+
+        :return: latest release value
+        """
+        with ftplib.FTP(self._host) as ftp:
+            ftp.login()
+            timestamp = ftp.voidcmd(f"MDTM {self._directory_path}{self._host_filename}")
+        return timestamp[4:12]
+
+    def _download_data(self, version: str, outfile: Path) -> None:
+        """Download data file to specified location.
+
+        :param version: version to acquire
+        :param outfile: location and filename for final data file
+        """
+        download_ftp(
+            self._host,
+            self._directory_path,
+            self._host_filename,
+            outfile,
+            tqdm_params=self._tqdm_params,
+        )

--- a/src/wags_tails/ncbi.py
+++ b/src/wags_tails/ncbi.py
@@ -1,0 +1,180 @@
+"""Provide data fetching for NCBI."""
+import ftplib
+import logging
+import re
+from pathlib import Path
+from typing import NamedTuple, Tuple
+
+from wags_tails.base_source import DataSource, RemoteDataError
+from wags_tails.utils.downloads import download_ftp, handle_gzip
+from wags_tails.utils.storage import get_latest_local_file
+from wags_tails.utils.versioning import parse_file_version
+
+_logger = logging.getLogger(__name__)
+
+
+class NcbiGenomeData(DataSource):
+    """Provide access to NCBI genome file."""
+
+    _src_name = "ncbi"
+    _filetype = "gff"
+
+    @staticmethod
+    def _navigate_ftp(ftp: ftplib.FTP) -> None:
+        """Navigate NCBI FTP filesystem to directory containing latest assembly annotation data.
+
+        :param ftp: logged-in FTP instance
+        :return: None, but modifies FTP connection in-place
+        :raise RemoteDataError: if navigation fails (e.g. because expected directories don't exist)
+        """
+        ftp.cwd(
+            "genomes/refseq/vertebrate_mammalian/Homo_sapiens/"
+            "latest_assembly_versions"
+        )
+        major_annotation_pattern = r"GCF_\d+\.\d+_GRCh\d+.+"
+        try:
+            grch_dirs = [d for d in ftp.nlst() if re.match(major_annotation_pattern, d)]
+            grch_dir = grch_dirs[0]
+        except (IndexError, AttributeError):
+            raise RemoteDataError(
+                "No directories matching expected NCBI latest assembly version pattern"
+            )
+        ftp.cwd(grch_dir)
+
+    def _get_latest_version(self) -> str:
+        """Retrieve latest version value
+
+        :return: latest release value
+        """
+        file_pattern = r"GCF_\d+\.\d+_(GRCh\d+\.\w\d+)_genomic.gff.gz"
+        with ftplib.FTP("ftp.ncbi.nlm.nih.gov") as ftp:
+            ftp.login()
+            self._navigate_ftp(ftp)
+            for file in ftp.nlst():
+                match = re.match(file_pattern, file)
+                if match and match.groups():
+                    latest_version = match.groups()[0]
+                    return latest_version
+        raise RemoteDataError(
+            "No files matching expected NCBI GRCh38 annotation pattern"
+        )
+
+    def _download_data(self, version: str, outfile: Path) -> None:
+        """Download data file to specified location.
+
+        :param version: version to acquire
+        :param outfile: location and filename for final data file
+        """
+        file_pattern = f"GCF_\\d+\\.\\d+_{version}_genomic.gff.gz"
+        genomic_filename = None
+        genomic_file_location = None
+        with ftplib.FTP("ftp.ncbi.nlm.nih.gov") as ftp:
+            ftp.login()
+            self._navigate_ftp(ftp)
+            for f in ftp.nlst():
+                gff_match = re.match(file_pattern, f)
+                if gff_match:
+                    genomic_filename = f
+                    genomic_file_location = ftp.pwd()
+            if not genomic_filename or not genomic_file_location:
+                raise RemoteDataError(
+                    "Unable to find latest available NCBI GRCh38 annotation"
+                )
+        download_ftp(
+            "ftp.ncbi.nlm.nih.gov",
+            genomic_file_location,
+            genomic_filename,
+            outfile,
+            handler=handle_gzip,
+            tqdm_params=self._tqdm_params,
+        )
+
+
+class NcbiGenePaths(NamedTuple):
+    """Container for NCBI Gene file paths."""
+
+    gene_info: Path
+    gene_history: Path
+
+
+class NcbiGeneData(DataSource):
+    """Provide access to Guide to Pharmacology data."""
+
+    _src_name = "ncbi"
+    _filetype = "tsv"
+
+    @staticmethod
+    def _get_latest_version() -> str:
+        """Retrieve latest version value.
+
+        NCBI appears to update the human gene info file a little after the history file,
+        so we'll key the overall version to that (this is also how we've been doing it
+        in the Gene Normalizer).
+
+        :return: latest release value
+        """
+        with ftplib.FTP("ftp.ncbi.nlm.nih.gov") as ftp:
+            ftp.login()
+            timestamp = ftp.voidcmd(
+                "MDTM gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz"
+            )
+        return timestamp[4:12]
+
+    def _download_data(self, file_paths: NcbiGenePaths) -> None:
+        """Perform file downloads.
+
+        :param file_paths: locations to save files at
+        """
+        download_ftp(
+            "ftp.ncbi.nlm.nih.gov",
+            "gene/DATA/GENE_INFO/Mammalia/",
+            "Homo_sapiens.gene_info.gz",
+            file_paths.gene_info,
+            handler=handle_gzip,
+            tqdm_params=self._tqdm_params,
+        )
+        download_ftp(
+            "ftp.ncbi.nlm.nih.gov",
+            "gene/DATA/",
+            "gene_history.gz",
+            file_paths.gene_history,
+            handler=handle_gzip,
+            tqdm_params=self._tqdm_params,
+        )
+
+    def get_latest(
+        self, from_local: bool = False, force_refresh: bool = False
+    ) -> Tuple[NcbiGenePaths, str]:
+        """Get path to latest version of data, and its version value
+
+        :param from_local: if True, use latest available local file
+        :param force_refresh: if True, fetch and return data from remote regardless of
+            whether a local copy is present
+        :return: Paths to data, and version value of it
+        :raise ValueError: if both ``force_refresh`` and ``from_local`` are True
+        """
+        if force_refresh and from_local:
+            raise ValueError("Cannot set both `force_refresh` and `from_local`")
+
+        if from_local:
+            info_path = get_latest_local_file(self.data_dir, "ncbi_info_*.tsv")
+            history_path = get_latest_local_file(self.data_dir, "ncbi_history_*.tsv")
+            file_paths = NcbiGenePaths(gene_info=info_path, gene_history=history_path)
+            return file_paths, parse_file_version(info_path, r"ncbi_info_(\d{8}).tsv")
+
+        latest_version = self._get_latest_version()
+        info_path = self.data_dir / f"ncbi_info_{latest_version}.tsv"
+        history_path = self.data_dir / f"ncbi_history_{latest_version}.tsv"
+        file_paths = NcbiGenePaths(gene_info=info_path, gene_history=history_path)
+        if not force_refresh:
+            if info_path.exists() and history_path.exists():
+                _logger.debug(
+                    f"Found existing files, {file_paths}, matching latest version {latest_version}."
+                )
+                return file_paths, latest_version
+            elif info_path.exists() or history_path.exists():
+                _logger.warning(
+                    f"Existing files, {file_paths}, not all available -- attempting full download."
+                )
+        self._download_data(file_paths)
+        return file_paths, latest_version

--- a/src/wags_tails/utils/downloads.py
+++ b/src/wags_tails/utils/downloads.py
@@ -1,4 +1,6 @@
 """Provide helper functions for downloading data."""
+import ftplib
+import gzip
 import logging
 import os
 import re
@@ -31,6 +33,65 @@ def handle_zip(dl_path: Path, outfile_path: Path) -> None:
     os.remove(dl_path)
 
 
+def handle_gzip(dl_path: Path, outfile_path: Path) -> None:
+    """Provide simple callback to extract file from gzip.
+
+    :param dl_path: path to temp data file
+    :param outfile_path: path to save file within
+    """
+    with gzip.open(dl_path, "rb") as gz:
+        with open(outfile_path, "wb") as f:
+            f.write(gz.read())
+
+
+def download_ftp(
+    host: str,
+    host_directory_path: str,
+    host_filename: str,
+    outfile_path: Path,
+    handler: Optional[Callable[[Path, Path], None]] = None,
+    tqdm_params: Optional[Dict] = None,
+) -> None:
+    """Perform FTP download of remote data file.
+
+    :param host: FTP hostname
+    :param host_directory_path: path to desired file on host
+    :param host_filename: name of desired file on host
+    :param outfile_path: path to where file should be saved. Must be an actual Path
+        instance rather than merely a pathlike string.
+    :param handler: provide if downloaded file requires additional action, e.g. it's a
+        zip file
+    :param tqdm_params: Optional TQDM configuration.
+    """
+    if not tqdm_params:
+        tqdm_params = {}
+    _logger.info(f"Downloading {outfile_path.name} from {host}...")
+    if handler:
+        dl_path = Path(tempfile.gettempdir()) / "wags_tails_tmp"
+    else:
+        dl_path = outfile_path
+    with ftplib.FTP(host) as ftp:
+        ftp.login()
+        _logger.debug(f"FTP login to {host} was successful.")
+        ftp.cwd(host_directory_path)
+        file_size = ftp.size(host_filename)
+        if not tqdm_params.get("disable"):
+            print(f"Downloading {host}/{host_directory_path}{host_filename}...")
+        with open(dl_path, "wb") as fp:
+            with tqdm(total=file_size, **tqdm_params) as progress_bar:
+
+                def _cb(data: bytes) -> None:
+                    progress_bar.update(len(data))
+                    fp.write(data)
+                    if fp.tell() == file_size:
+                        progress_bar.close()
+
+                ftp.retrbinary(f"RETR {host_filename}", _cb)
+    if handler:
+        handler(dl_path, outfile_path)
+    _logger.info(f"Successfully downloaded {outfile_path.name}.")
+
+
 def download_http(
     url: str,
     outfile_path: Path,
@@ -59,14 +120,14 @@ def download_http(
     with requests.get(url, stream=True, headers=headers) as r:
         r.raise_for_status()
         total_size = int(r.headers.get("content-length", 0))
+        if not tqdm_params.get("disable"):
+            if "apiKey" in url:  # don't print RxNorm API key
+                pattern = r"&apiKey=.{8}-.{4}-.{4}-.{4}-.{12}"
+                print_url = re.sub(pattern, "", os.path.basename(url))
+                print(f"Downloading {print_url}...")
+            else:
+                print(f"Downloading {os.path.basename(url)}...")
         with open(dl_path, "wb") as h:
-            if not tqdm_params["disable"]:
-                if "apiKey" in url:  # don't print RxNorm API key
-                    pattern = r"&apiKey=.{8}-.{4}-.{4}-.{4}-.{12}"
-                    print_url = re.sub(pattern, "", os.path.basename(url))
-                    print(f"Downloading {print_url}...")
-                else:
-                    print(f"Downloading {os.path.basename(url)}...")
             with tqdm(
                 total=total_size,
                 **tqdm_params,

--- a/tests/test_ensembl.py
+++ b/tests/test_ensembl.py
@@ -1,0 +1,38 @@
+"""Test Ensembl data source."""
+from pathlib import Path
+
+import pytest
+
+from wags_tails import EnsemblData
+
+
+@pytest.fixture(scope="function")
+def ensembl_data_dir(base_data_dir: Path):
+    """Provide Ensembl data directory."""
+    dir = base_data_dir / "ensembl"
+    dir.mkdir(exist_ok=True, parents=True)
+    return dir
+
+
+@pytest.fixture(scope="function")
+def ensembl(ensembl_data_dir: Path):
+    """Provide ChemblData fixture"""
+    return EnsemblData(ensembl_data_dir, silent=True)
+
+
+def test_get_latest_local(
+    ensembl: EnsemblData,
+    ensembl_data_dir: Path,
+):
+    """Test local file management in EnsemblData.get_latest()"""
+    with pytest.raises(ValueError):
+        ensembl.get_latest(from_local=True, force_refresh=True)
+
+    with pytest.raises(FileNotFoundError):
+        ensembl.get_latest(from_local=True)
+
+    file_path = ensembl_data_dir / "ensembl_GRCh38_110.gff"
+    file_path.touch()
+    path, version = ensembl.get_latest(from_local=True)
+    assert path == file_path
+    assert version == "GRCh38_110"

--- a/tests/test_hgnc.py
+++ b/tests/test_hgnc.py
@@ -1,0 +1,38 @@
+"""Test HGNC data source."""
+from pathlib import Path
+
+import pytest
+
+from wags_tails import HgncData
+
+
+@pytest.fixture(scope="function")
+def hgnc_data_dir(base_data_dir: Path):
+    """Provide HGNC data directory."""
+    dir = base_data_dir / "hgnc"
+    dir.mkdir(exist_ok=True, parents=True)
+    return dir
+
+
+@pytest.fixture(scope="function")
+def hgnc(hgnc_data_dir: Path):
+    """Provide ChemblData fixture"""
+    return HgncData(hgnc_data_dir, silent=True)
+
+
+def test_get_latest_local(
+    hgnc: HgncData,
+    hgnc_data_dir: Path,
+):
+    """Test local file management in HgncData.get_latest()"""
+    with pytest.raises(ValueError):
+        hgnc.get_latest(from_local=True, force_refresh=True)
+
+    with pytest.raises(FileNotFoundError):
+        hgnc.get_latest(from_local=True)
+
+    file_path = hgnc_data_dir / "hgnc_20230914.json"
+    file_path.touch()
+    path, version = hgnc.get_latest(from_local=True)
+    assert path == file_path
+    assert version == "20230914"

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -1,0 +1,65 @@
+"""Test NCBI data source."""
+from pathlib import Path
+
+import pytest
+
+from wags_tails import NcbiGeneData, NcbiGenomeData
+
+
+@pytest.fixture(scope="function")
+def ncbi_data_dir(base_data_dir: Path):
+    """Provide NCBI data directory."""
+    dir = base_data_dir / "ncbi"
+    dir.mkdir(exist_ok=True, parents=True)
+    return dir
+
+
+@pytest.fixture(scope="function")
+def ncbi_genome(ncbi_data_dir: Path):
+    """Provide NcbiGenomeData fixture"""
+    return NcbiGenomeData(ncbi_data_dir, silent=True)
+
+
+@pytest.fixture(scope="function")
+def ncbi_gene(ncbi_data_dir: Path):
+    """Provide NcbiGeneData fixture"""
+    return NcbiGeneData(ncbi_data_dir, silent=True)
+
+
+def test_genome_get_latest_local(
+    ncbi_genome: NcbiGenomeData,
+    ncbi_data_dir: Path,
+):
+    """Test local file management in NcbiGenomeData.get_latest()"""
+    with pytest.raises(ValueError):
+        ncbi_genome.get_latest(from_local=True, force_refresh=True)
+
+    with pytest.raises(FileNotFoundError):
+        ncbi_genome.get_latest(from_local=True)
+
+    file_path = ncbi_data_dir / "ncbi_GRCh38.p14.gff"
+    file_path.touch()
+    path, version = ncbi_genome.get_latest(from_local=True)
+    assert path == file_path
+    assert version == "GRCh38.p14"
+
+
+def test_info_get_latest_local(
+    ncbi_gene: NcbiGeneData,
+    ncbi_data_dir: Path,
+):
+    """Test local file management in NcbiGeneData.get_latest()"""
+    with pytest.raises(ValueError):
+        ncbi_gene.get_latest(from_local=True, force_refresh=True)
+
+    with pytest.raises(FileNotFoundError):
+        ncbi_gene.get_latest(from_local=True)
+
+    info_file_path = ncbi_data_dir / "ncbi_info_20230914.tsv"
+    info_file_path.touch()
+    history_file_path = ncbi_data_dir / "ncbi_history_20230914.tsv"
+    history_file_path.touch()
+    paths, version = ncbi_gene.get_latest(from_local=True)
+    assert paths.gene_info == info_file_path
+    assert paths.gene_history == history_file_path
+    assert version == "20230914"


### PR DESCRIPTION
* I split up the NCBI stuff because I think that while gene info/history are sort of tightly coupled (ideally they should be the same version), they're qualitatively different, and not dependent on, the genome annotation file.
* We get all this stuff via FTP. It's a lot harder to mock (I didn't bother here -- we weren't previously mocking it in Gene Normalizer tests) and also the EBI FTP server seems to just block login attempts sometimes... might be worth it to just switch to HTTP.