### PR TITLE
docs: fix CLI command name

### DIFF
--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -11,5 +11,5 @@ enabling usage from non-Python environments or for general data management purpo
    Currently, the CLI routes data requests through the explicitly defined source modules within ``wags-tails``. This means that the CLI cannot be used to manage custom sources.
 
 .. click:: wags_tails.cli:cli
-   :prog: wags_tails
+   :prog: wags-tails
    :nested: full


### PR DESCRIPTION
of course I only notice this after merging