### PR TITLE
feat: use HPO base instead of full

### DIFF
--- a/src/wags_tails/hpo.py
+++ b/src/wags_tails/hpo.py
@@ -43,11 +43,11 @@ class HpoData(GitHubDataSource):
         assets = data["assets"]
         url = None
         for asset in assets:
-            if asset["name"] == "hp-full.obo":
+            if asset["name"] == "hp-base.obo":
                 url = asset["browser_download_url"]
                 return (version, url)
         else:
-            msg = f"Unable to retrieve hp-full.obo under release {version}"
+            msg = f"Unable to retrieve hp-base.obo under release {version}"
             raise RemoteDataError(msg)
 
     def _download_data(self, version: str, outfile: Path) -> None:
@@ -62,7 +62,7 @@ class HpoData(GitHubDataSource):
             .strftime("%Y-%m-%d")
         )
         download_http(
-            f"https://github.com/{self._repo}/releases/download/{formatted_version}/hp-full.obo",
+            f"https://github.com/{self._repo}/releases/download/{formatted_version}/hp-base.obo",
             outfile,
             tqdm_params=self._tqdm_params,
         )

--- a/tests/test_hpo.py
+++ b/tests/test_hpo.py
@@ -50,7 +50,7 @@ def test_get_latest(
             json=latest_release_response,
         )
         m.get(
-            "https://github.com/obophenotype/human-phenotype-ontology/releases/download/2025-03-03/hp-full.obo",
+            "https://github.com/obophenotype/human-phenotype-ontology/releases/download/2025-03-03/hp-base.obo",
             body="",
         )
         path, version = hpo.get_latest()


### PR DESCRIPTION
Minor change, but the nicest Python OBO parser hates some syntax that's present in the full HPO release. Everything we want is in the base release, though, and it makes sense to use a lighter file anyway.
