### PR TITLE
feat: Add network request retry for `ncbi_lrg_refseqgene.py`

### DIFF
--- a/src/wags_tails/ncbi_lrg_refseqgene.py
+++ b/src/wags_tails/ncbi_lrg_refseqgene.py
@@ -1,13 +1,10 @@
 """Fetches NCBI LRG_RefSeqGene data."""
 
 import re
-import time
 from pathlib import Path
 
-import requests
-
 from .base_source import DataSource, RemoteDataError
-from .utils.downloads import HTTPS_REQUEST_TIMEOUT, MAX_RETRIES, download_http
+from .utils.downloads import download_http, request_get_with_retries
 
 
 class NcbiLrgRefSeqGeneData(DataSource):
@@ -23,17 +20,7 @@ class NcbiLrgRefSeqGeneData(DataSource):
         :raise RemoteDataError: if unable to parse version number from file directory
         """
         url = "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene/"
-        response = None
-        for attempt in range(1, MAX_RETRIES + 1):
-            try:
-                response = requests.get(url, timeout=HTTPS_REQUEST_TIMEOUT)
-                response.raise_for_status()
-                break
-            except RemoteDataError as rde:
-                if attempt == MAX_RETRIES:
-                    msg = f"Unable to fetch LRG_RefSeqGene data after {MAX_RETRIES} attempts"
-                    raise RemoteDataError(msg) from rde
-                time.sleep(1)
+        response = request_get_with_retries(url)
         text = response.text
         for row in text.split("\n"):
             if "LRG_RefSeqGene" in row:

--- a/src/wags_tails/ncbi_lrg_refseqgene.py
+++ b/src/wags_tails/ncbi_lrg_refseqgene.py
@@ -4,7 +4,11 @@ import re
 from pathlib import Path
 
 from .base_source import DataSource, RemoteDataError
-from .utils.downloads import download_http, request_get_with_retries
+from .utils.downloads import (
+    HTTPS_REQUEST_TIMEOUT,
+    download_http,
+    request_get_with_retries,
+)
 
 
 class NcbiLrgRefSeqGeneData(DataSource):
@@ -20,7 +24,7 @@ class NcbiLrgRefSeqGeneData(DataSource):
         :raise RemoteDataError: if unable to parse version number from file directory
         """
         url = "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene/"
-        response = request_get_with_retries(url, timeout=30)
+        response = request_get_with_retries(url, timeout=HTTPS_REQUEST_TIMEOUT)
         response.raise_for_status()
         text = response.text
         for row in text.split("\n"):

--- a/src/wags_tails/ncbi_lrg_refseqgene.py
+++ b/src/wags_tails/ncbi_lrg_refseqgene.py
@@ -1,12 +1,13 @@
 """Fetches NCBI LRG_RefSeqGene data."""
 
 import re
+import time
 from pathlib import Path
 
 import requests
 
 from .base_source import DataSource, RemoteDataError
-from .utils.downloads import HTTPS_REQUEST_TIMEOUT, download_http
+from .utils.downloads import HTTPS_REQUEST_TIMEOUT, MAX_RETRIES, download_http
 
 
 class NcbiLrgRefSeqGeneData(DataSource):
@@ -22,8 +23,17 @@ class NcbiLrgRefSeqGeneData(DataSource):
         :raise RemoteDataError: if unable to parse version number from file directory
         """
         url = "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene/"
-        response = requests.get(url, timeout=HTTPS_REQUEST_TIMEOUT)
-        response.raise_for_status()
+        response = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = requests.get(url, timeout=HTTPS_REQUEST_TIMEOUT)
+                response.raise_for_status()
+                break
+            except RemoteDataError as rde:
+                if attempt == MAX_RETRIES:
+                    msg = f"Unable to fetch LRG_RefSeqGene data after {MAX_RETRIES} attempts"
+                    raise RemoteDataError(msg) from rde
+                time.sleep(1)
         text = response.text
         for row in text.split("\n"):
             if "LRG_RefSeqGene" in row:

--- a/src/wags_tails/ncbi_lrg_refseqgene.py
+++ b/src/wags_tails/ncbi_lrg_refseqgene.py
@@ -20,7 +20,8 @@ class NcbiLrgRefSeqGeneData(DataSource):
         :raise RemoteDataError: if unable to parse version number from file directory
         """
         url = "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene/"
-        response = request_get_with_retries(url)
+        response = request_get_with_retries(url, timeout=30)
+        response.raise_for_status()
         text = response.text
         for row in text.split("\n"):
             if "LRG_RefSeqGene" in row:

--- a/src/wags_tails/utils/downloads.py
+++ b/src/wags_tails/utils/downloads.py
@@ -11,7 +11,10 @@ from collections.abc import Callable
 from pathlib import Path
 
 import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
 from tqdm import tqdm
+from urllib3.util import Retry
 
 _logger = logging.getLogger(__name__)
 
@@ -46,6 +49,23 @@ def handle_gzip(dl_path: Path, outfile_path: Path) -> None:
     """
     with gzip.open(dl_path, "rb") as gz, outfile_path.open("wb") as f:
         f.write(gz.read())
+
+
+def request_get_with_retries(url: str) -> requests.Response:
+    """Run request calls for a session given a url
+
+    :param url: The URL where the data will be downloaded from
+    :return: A requests.Response object
+    """
+    session = Session()
+    retries = Retry(
+        total=MAX_RETRIES,
+        backoff_factor=0.1,
+        status_forcelist=[502, 503, 504],
+        allowed_methods={"GET"},
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+    return session.get(url, timeout=30)
 
 
 def download_ftp(

--- a/src/wags_tails/utils/downloads.py
+++ b/src/wags_tails/utils/downloads.py
@@ -17,6 +17,7 @@ _logger = logging.getLogger(__name__)
 
 
 HTTPS_REQUEST_TIMEOUT = 30
+MAX_RETRIES = 3
 
 
 def handle_zip(dl_path: Path, outfile_path: Path) -> None:

--- a/src/wags_tails/utils/downloads.py
+++ b/src/wags_tails/utils/downloads.py
@@ -51,10 +51,11 @@ def handle_gzip(dl_path: Path, outfile_path: Path) -> None:
         f.write(gz.read())
 
 
-def request_get_with_retries(url: str) -> requests.Response:
+def request_get_with_retries(url: str, **kwargs) -> requests.Response:
     """Run request calls for a session given a url
 
     :param url: The URL where the data will be downloaded from
+    :param kwargs: Optional arguments to supply to the sesion.get command
     :return: A requests.Response object
     """
     session = Session()
@@ -65,7 +66,7 @@ def request_get_with_retries(url: str) -> requests.Response:
         allowed_methods={"GET"},
     )
     session.mount("https://", HTTPAdapter(max_retries=retries))
-    return session.get(url, timeout=30)
+    return session.get(url, **kwargs)
 
 
 def download_ftp(


### PR DESCRIPTION
closes #83 

Note: I had ChatGPT assist me here, but this seems to be a logical solution for the `ncbi_lrg_refseqgene.py` module. There are other harvesters that don't have the network retry logic, so I am wondering if we should add this in other places, or add a new module that can imported from `utils` that does the network retry